### PR TITLE
misc: ipts: Fix NULL pointer dereference in ipts_hid_release()

### DIFF
--- a/drivers/misc/ipts/ipts-hid.c
+++ b/drivers/misc/ipts/ipts-hid.c
@@ -286,8 +286,9 @@ err_dev:
 
 void ipts_hid_release(ipts_info_t *ipts)
 {
-	struct hid_device *hid = ipts->hid;
-	hid_destroy_device(hid);
+	if (!ipts->hid)
+		return;
+	hid_destroy_device(ipts->hid);
 }
 
 int ipts_handle_hid_data(ipts_info_t *ipts,


### PR DESCRIPTION
If we failed to add a hid device (e.g. firmware failed to load),
ipts_hid_release() will still be called (by mei_cl_device_remove()) on
shutdown, which in turn will cause ipts->hid to be dereferenced.

Signed-off-by: Anton Vorontsov <anton@enomsg.org>